### PR TITLE
@releng Update readme to mention the correct port of the local instance

### DIFF
--- a/react-app/README.md
+++ b/react-app/README.md
@@ -17,7 +17,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:9000](http://localhost:9000) to view it in the browser.
 The AEM instance must allow the Cross-Origin Resource Sharing with your local server. See the following [documentation](https://helpx.adobe.com/experience-manager/kt/platform-repository/using/cors-security-article-understand.html) for more detail
 
 The page will reload if you make edits.<br>


### PR DESCRIPTION
* 3000 seems like a Typo. Actually, the port 9000 is used
* Details are already mentioned in [DEVELOPMENT.md](https://github.com/adobe/aem-sample-we-retail-journal/blob/master/react-app/DEVELOPMENT.md) which also mention the correct port : 9000