### PR TITLE
Adding request parameter limit

### DIFF
--- a/react-app/src/server/index.js
+++ b/react-app/src/server/index.js
@@ -32,7 +32,6 @@ const exapp = express();
 //Here we are configuring express to use body-parser as middle-ware.
 exapp.use(bodyParser.urlencoded({limit: "50mb", extended: false, parameterLimit:process.env.PARAMETER_LIMIT}));
 exapp.use(bodyParser.json({limit: "50mb"}));
-exapp.use(bodyParser.json());
 exapp.use(express.static("dist"));
 
 const APP_ROOT_PATH = process.env.APP_ROOT_PATH;


### PR DESCRIPTION
Hi @gknobloch and @sharanyavinod,
 
When the number of pages increase just more than 30 then below error occured.

PayloadTooLargeError: request entity too large
    at readStream  (/Users/zospakir/Projects/AEM/Code/SPA/we-retail/aem-sample-we-retail-journal/react-app/node_modules/raw-body/index.js:155:17)
    at getRawBody (/Users/zospakir/Projects/AEM/Code/SPA/we-retail/aem-sample-we-retail-journal/react-app/node_modules/raw-body/index.js:108:12)

I have added request parameter which solves it. Please have a look at my PR.

Thanks,
Pakira 